### PR TITLE
Adding composer installers "type" property.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
       "custom-meta-boxes.php"
     ]
   },
+  "type": "wordpress-plugin",
   "require": {
     "composer/installers": "~1.0"
   }


### PR DESCRIPTION


{{Allow Install Path to Be Overridden}}

Resolves -

In order for `composer/installers` to work (and allow path overrides), the package must have a `type` property. I have added a type of `wordpress-plugin`, allowing it to be overridden in the hosts composer.json.

*I have:*
 - [ x ] Run WordPress VIP PHPCS check and code parses without errors
 - [ x ] Added any new PHPUnit tests
 - [ x ] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [ x ] Tested feature/bugfix on single and multisite install
